### PR TITLE
Allow skipping of entire signal-cli registration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,6 @@ signal_force_re_registration: False
 # interactive mode or not. Since I haven't been able to find such a fact, the
 # following var is used instead and set to False by default to be safe.
 ansible_interactive_mode: False
+
+# Allow skipping registration of signal CLI registration task
+signal_cli_register: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,5 @@
 ---
 - include: download_install_signal_cli.yml
+
 - include: register_signal_number.yml
+  when: signal_cli_register


### PR DESCRIPTION
This is useful when you want to install the CLI tooling but are not ready to
register the tool to a specific number yet.